### PR TITLE
If available, use c99 to our advantage (read commit msg)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ CHECK_TYPE_SIZE("short" SIZEOF_SHORT)
 TEST_BIG_ENDIAN(HOST_BIG_ENDIAN)
 
 check_c_compiler_flag(-fvisibility=hidden EVHTP_HAS_VISIBILITY_HIDDEN)
+check_c_compiler_flag(-std=c99 EVHTP_HAS_C99)
+
+if (EVHTP_HAS_C99)
+	add_definitions(-DEVHTP_HAS_C99)
+endif()
 
 if (EVHTP_HAS_VISIBILITY_HIDDEN)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")


### PR DESCRIPTION
- if the compiler supports c99, functions which rely on temporary allocations
  based o the input size, use 'char whatever[size]' instead of malloc.

- is_http_XX are now macros.

- cleanup function recently added with lots of goto'so