### PR TITLE
build: install evhtp.pc in /usr/lib/pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,8 @@ ENDIF (WIN32)
 configure_file(
 	${CMAKE_CURRENT_SOURCE_DIR}/evhtp.pc.in
 	${CMAKE_CURRENT_BINARY_DIR}/evhtp.pc @ONLY)
+install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/evhtp.pc"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
 
 # add_definitions() calls do not show up in the C_FLAGS var
 # it is instead a property of COMPILE_DEFINITIONS.


### PR DESCRIPTION
Without installing it, it is easy to miss this useful file.