### PR TITLE
uint64_t check can never be greater than UINT64_MAX

### DIFF
--- a/htparse.c
+++ b/htparse.c
@@ -328,7 +328,7 @@ str_to_uint64(char * str, size_t n, int * err) {
 
         check = value * 10 + (*str - '0');
 
-        if ((value && check <= value) || check > UINT64_MAX) {
+        if ((value && check <= value)) {
             *err = 1;
             return 0;
         }


### PR DESCRIPTION
uint64_t check can never be greater than UINT64_MAX
remove the meaningless code