### PR TITLE
some improvements about HEAD method and non-keepalived response

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -1962,6 +1962,8 @@ _evhtp_connection_eventcb(evbev_t * bev, short events, void * arg) {
             errno = 0;
 
             return;
+        } else {
+            htparser_run(c->parser, &request_psets, (const char *)NULL, 0);
         }
     }
 

--- a/htparse.c
+++ b/htparse.c
@@ -404,6 +404,11 @@ htparser_should_keep_alive(htparser * p) {
     return 0;
 }
 
+htp_type
+htparser_get_type(htparser * p) {
+    return p->type;
+}
+
 htp_scheme
 htparser_get_scheme(htparser * p) {
     return p->scheme;
@@ -1816,9 +1821,12 @@ hdrline_start:
                     case LF:
                         res = hook_on_hdrs_complete_run(p, hooks);
 
-                        if (res) {
+                        if (res < 0) {
                             p->error = htparse_error_user;
                             return i + 1;
+                        }
+                        else if (res > 0) {
+                            p->flags |= parser_flag_trailing;
                         }
 
 

--- a/htparse.h
+++ b/htparse.h
@@ -96,6 +96,7 @@ struct htparse_hooks {
 
 EVHTP_EXPORT size_t         htparser_run(htparser *, htparse_hooks *, const char *, size_t);
 EVHTP_EXPORT int            htparser_should_keep_alive(htparser * p);
+EVHTP_EXPORT htp_type       htparser_get_type(htparser *);
 EVHTP_EXPORT htp_scheme     htparser_get_scheme(htparser *);
 EVHTP_EXPORT htp_method     htparser_get_method(htparser *);
 EVHTP_EXPORT const char   * htparser_get_methodstr(htparser *);


### PR DESCRIPTION
# Client:
1. response for HEAD method ingore body;
2. non-chunked response without 'Content-Length' header, then read body until server socket close.

# Sever:
1. auto set "Content-Length" header, when synchronous response is issued by function evhtp_send_reply() ; 
2. asynchronous response without "Content-Length" header, so must close socket to indicate the end of body.