### PR TITLE
(evhtp_send_reply): Grab reference to bufferevent during write.

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -3045,6 +3045,7 @@ void
 evhtp_send_reply(evhtp_request_t * request, evhtp_res code) {
     evhtp_connection_t * c;
     evbuf_t            * reply_buf;
+    struct bufferevent * bev;
 
     c = evhtp_request_get_connection(request);
     request->finished = 1;
@@ -3055,7 +3056,10 @@ evhtp_send_reply(evhtp_request_t * request, evhtp_res code) {
         return;
     }
 
-    bufferevent_write_buffer(evhtp_connection_get_bev(c), reply_buf);
+    bev = evhtp_connection_get_bev(c);
+    bufferevent_lock(bev);
+    bufferevent_write_buffer(bev, reply_buf);
+    bufferevent_unlock(bev);
     evbuffer_drain(reply_buf, -1);
     /* evbuffer_free(reply_buf); */
 }


### PR DESCRIPTION
This should fix issue #195.