### PR TITLE
Remove double-free when SSL is used.

### DIFF
--- a/evhtp.c
+++ b/evhtp.c
@@ -4250,7 +4250,7 @@ evhtp_free(evhtp_t * evhtp) {
 
 #ifndef EVHTP_DISABLE_SSL
     if (evhtp->ssl_ctx) {
-        SSL_CTX_free(evhtp->ssl_ctx);
+        evhtp_safe_free(evhtp->ssl_ctx, SSL_CTX_free);
     }
 #endif
 
@@ -4270,12 +4270,6 @@ evhtp_free(evhtp_t * evhtp) {
         TAILQ_REMOVE(&evhtp->aliases, evhtp_alias, next);
         evhtp_safe_free(evhtp_alias, free);
     }
-
-#ifndef EVHTP_DISABLE_SSL
-    if (evhtp->ssl_ctx) {
-        SSL_CTX_free(evhtp->ssl_ctx);
-    }
-#endif
 
     evhtp_safe_free(evhtp, free);
 } /* evhtp_free */


### PR DESCRIPTION
Two PRs, #143 and #99, close a memory leak by freeing `evhtp_t.ssl_ctx`.
Since they modify the same function at different points within the
function `evhtp_free`, the memory is freed twice. This patch removes the
second call to `SSL_CTX_free()`.

Releases are affected as follows:
before 1.2.7: `evhtp_t.ssl_ctx` is leaked
1.2.7 through 1.2.9: OK
1.2.10 and 1.2.11: `evhtp_t.ssl_ctx` is freed twice